### PR TITLE
Replace ISJ 鎌ヶ谷市 to 鎌ケ谷市 in import script

### DIFF
--- a/data-patches/isj/patches/2024061101_replace_kamagaya.sql
+++ b/data-patches/isj/patches/2024061101_replace_kamagaya.sql
@@ -1,0 +1,3 @@
+UPDATE pggeocoder.address_s SET shikuchoson = '鎌ケ谷市' WHERE todofuken = '千葉県' AND shikuchoson = '鎌ヶ谷市';
+UPDATE pggeocoder.address_o SET shikuchoson = '鎌ケ谷市' WHERE todofuken = '千葉県' AND shikuchoson = '鎌ヶ谷市';
+UPDATE pggeocoder.address_c SET shikuchoson = '鎌ケ谷市' WHERE todofuken = '千葉県' AND shikuchoson = '鎌ヶ谷市';

--- a/scripts/import_isj.sh
+++ b/scripts/import_isj.sh
@@ -25,7 +25,7 @@ IN_OAZA_CSV_DIR=${IN_OAZA_DIR}/${year}/csv
 IN_GAIKU_DIR=${IN_ROOT_DIR}/gaiku
 IN_GAIKU_CSV_DIR=${IN_GAIKU_DIR}/${year}/csv
 
-IN_PATCHES_CSV_DIR=${SCRIPT_DIR}/../data-patches/isj/patches
+IN_PATCHES_DIR=${SCRIPT_DIR}/../data-patches/isj/patches
 
 if [ ! -d ${IN_OAZA_CSV_DIR} ] || [ ! -d ${IN_GAIKU_CSV_DIR} ]; then
   echo "CSV files are not downloaded yet" 1>&2
@@ -63,9 +63,12 @@ psql -U ${DBROLE} -d ${DBNAME} -f ./sql/isj/convertISJDatas.sql
 
 # Patch address tables
 echo -e "\nPatching address tables..."
-for csv in ${IN_PATCHES_CSV_DIR}/address_*.csv ; do
+for csv in ${IN_PATCHES_DIR}/address_*.csv ; do
   table_name=`basename ${csv} .csv`
   psql -U ${DBROLE} -d ${DBNAME} -c "\copy pggeocoder.${table_name} from '${csv}' with delimiter ',' csv header;"
+done
+for sql in ${IN_PATCHES_DIR}/*.sql ; do
+  psql -U ${DBROLE} -d ${DBNAME} -f ${sql}
 done
 
 echo -e "\nDone!"


### PR DESCRIPTION
@mbasa This is patch script to replace ISJ `鎌ヶ谷市` to `鎌ケ谷市` in `address_(s|o|c)` tables.
I confirmed that other datasources (KSJ, eStat and ABR) are using `鎌ケ谷市` already, so I think that this patch is enough.