### PR TITLE
Fix specific city (政令指定都市) search

### DIFF
--- a/scripts/import_isj.sh
+++ b/scripts/import_isj.sh
@@ -70,5 +70,9 @@ done
 for sql in ${IN_PATCHES_DIR}/*.sql ; do
   psql -U ${DBROLE} -d ${DBNAME} -f ${sql}
 done
+# Make sure normalization after patching
+psql -U ${DBROLE} -d ${DBNAME} -c "update pggeocoder.address_o set tr_ooaza = normalizeAddr(ooaza);"
+psql -U ${DBROLE} -d ${DBNAME} -c "update pggeocoder.address_s set tr_shikuchoson = normalizeAddr(shikuchoson);"
+psql -U ${DBROLE} -d ${DBNAME} -c "update pggeocoder.address_o set tr_shikuchoson = normalizeAddr(shikuchoson);"
 
 echo -e "\nDone!"

--- a/sql/pgGeocoder.sql
+++ b/sql/pgGeocoder.sql
@@ -338,10 +338,12 @@ BEGIN
     IF r_todofuken <> '' THEN
       SELECT INTO rec * FROM pggeocoder.address_s WHERE 
       todofuken = r_todofuken AND
-      address LIKE '%'||substr(tr_shikuchoson,strpos(tr_shikuchoson,'郡')+1)||'%';
+      address LIKE '%'||substr(tr_shikuchoson,strpos(tr_shikuchoson,'郡')+1)||'%'
+      ORDER BY length(tr_shikuchoson) DESC;
     ELSE
       SELECT INTO rec * FROM pggeocoder.address_s WHERE 
-      address LIKE substr(tr_shikuchoson,strpos(tr_shikuchoson,'郡')+1)||'%';
+      address LIKE substr(tr_shikuchoson,strpos(tr_shikuchoson,'郡')+1)||'%'
+      ORDER BY length(tr_shikuchoson) DESC;
     END IF;
   END IF;
 


### PR DESCRIPTION
@mbasa I noticed that specific city (政令指定都市) in patch csv (https://github.com/mbasa/pgGeocoder/blob/develop/data-patches/isj/patches/address_s.csv) `tr_shikuchoson` column values are null, so I add further normalization process after patching ISJ data.

I also noticed that specific city (政令指定都市) search is failing when `address_s` table row is sorted by code, so I added order by desc to match longest value.