### PR TITLE
Support CI

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,0 +1,60 @@
+name: Test macOS
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  test-macos:
+    runs-on: ${{ matrix.os }}
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+
+    steps:
+      - name: Checkout pgGeocoder
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install postgresql postgis
+
+      - name: Install pgTAP
+        run: |
+          git clone https://github.com/theory/pgtap.git pgTapExtension
+          cd pgTapExtension
+          make -j
+          make install
+          cpan TAP::Parser::SourceHandler::pgTAP
+          ln -s $(find `brew --prefix` -name pg_prove) symlink it into $(brew --prefix)/bin
+
+      - name: Start PostgreSQL
+        run: |
+          pg_ctl -D $(brew --prefix)/var/postgresql@14 start
+          createuser -s postgres
+
+      - name: Wait PostgreSQL launch
+        run: |
+          pg_isready -U postgres -h localhost -p 5432
+          psql -U postgres -h localhost -p 5432 -c "SELECT version();"
+
+      - name: Set up database
+        run: |
+          cp .env.example .env
+          cp tests/.env.test tests/.env
+          bash tests/create_test_db_from_fixtures.sh
+      
+      - name: Run test
+        run: |
+          cd tests/normalize-japanese-addresses
+          pg_prove -U postgres -h localhost -p 5432 -d addresses_test addresses.test.sql
+          pg_prove -U postgres -h localhost -p 5432 -d addresses_test main.test.sql

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -1,0 +1,71 @@
+name: Test Ubuntu
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  test-ubuntu:
+    runs-on: ${{ matrix.os }}
+  
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
+
+    steps:
+      - name: Checkout pgGeocoder
+        uses: actions/checkout@v4
+
+      - name: Set PostgreSQL/PostGIS major version
+        run: |
+          pg_major=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d+ \()')
+          echo "PG_MAJOR=${pg_major}" >> $GITHUB_ENV
+          echo "POSTGIS_MAJOR=3" >> $GITHUB_ENV
+
+      - name: Add PostgreSQL APT repository
+        run: |
+          sudo apt-get install curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libtap-parser-sourcehandler-pgtap-perl \
+            postgresql-${PG_MAJOR} \
+            postgresql-${PG_MAJOR}-pgtap \
+            postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR} \
+            postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}-scripts
+
+      - name: Start PostgreSQL (with trust authentication)
+        run: |
+          sudo sed -i "s/\(peer\|scram-sha-256\)$/trust/g" "/etc/postgresql/${PG_MAJOR}/main/pg_hba.conf"
+          sudo cat "/etc/postgresql/${PG_MAJOR}/main/pg_hba.conf"
+          sudo systemctl start postgresql.service
+
+      - name: Wait PostgreSQL launch
+        run: |
+          pg_isready -U postgres -h localhost -p 5432
+          psql -U postgres -h localhost -p 5432 -c "SELECT version();"
+
+      - name: Set up database
+        run: |
+          cp .env.example .env
+          cp tests/.env.test tests/.env
+          bash tests/create_test_db_from_fixtures.sh
+      
+      - name: Run test
+        run: |
+          cd tests/normalize-japanese-addresses
+          pg_prove -U postgres -h localhost -p 5432 -d addresses_test addresses.test.sql
+          pg_prove -U postgres -h localhost -p 5432 -d addresses_test main.test.sql


### PR DESCRIPTION
@mbasa I added CI for tests on Ubuntu and macOS.
And now the following tests are failing in addresses.csv test.

* Ubuntu:
  * 24.04: https://github.com/gtt-project/pgGeocoder/actions/runs/9611494283/job/26510173350#step:9:32
  * 22.04: https://github.com/gtt-project/pgGeocoder/actions/runs/9611494283/job/26510173609
* macOS:
  * latest: https://github.com/gtt-project/pgGeocoder/actions/runs/9611494281/job/26510173360#step:8:29

```
addresses.test.sql .. 
# Failed test 443: "千葉県流山市鰭ケ崎１７６１－３"
#         have: {千葉県,流山市,大字鰭ケ崎}
#         want: {千葉県,流山市,鰭ケ崎}
# Failed test 444: "千葉県流山市鰭ケ崎４８７－１"
#         have: {千葉県,流山市,大字鰭ケ崎}
#         want: {千葉県,流山市,鰭ケ崎}
# Failed test 3404: "東京都新宿区三栄町１７－１６"
#         have: {東京都,新宿区,NULL}
#         want: {東京都,新宿区,四谷三栄町}
# Failed test 3405: "東京都新宿区三栄町２－８"
#         have: {東京都,新宿区,NULL}
#         want: {東京都,新宿区,四谷三栄町}
# Looks like you failed 4 tests of 7[10](https://github.com/gtt-project/pgGeocoder/actions/runs/9535086024/job/26280381990#step:9:11)1
Failed 4/7101 subtests
```

~~Most of the commits in this PR branch are just try and error, so when merging this, squashing commits will be better.~~
=> Well, I squash the commits from the latest develop branch.